### PR TITLE
Run On Port 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   ui:
     image: covid-hackathon-ui:latest
     ports:
-      - 5001:80
+      - 80:80
     environment:
       - "API_URL=http://web:5000"
   db:


### PR DESCRIPTION
# Overview

We should run the React app on port 80, not 5051, because we can't specify ports from DNS and this is the entrypoint to our webapp