### PR TITLE
Configure metrics

### DIFF
--- a/react-app/src/components/Page/index.js
+++ b/react-app/src/components/Page/index.js
@@ -5,11 +5,12 @@ import { useLocation } from 'react-router-dom';
 
 const Page = ({ className, children }) => {
   const location = useLocation();
+  const ga = window?.ga;
 
   useEffect(() => {
     // TODO: Make tag an environment variable (?)
-    window?.ga?.('gtag_UA_162388545_1.send', 'pageview', location.pathname); // eslint-disable-line no-unused-expressions
-  }, [location, window?.ga]);
+    ga?.('gtag_UA_162388545_1.send', 'pageview', location.pathname); // eslint-disable-line no-unused-expressions
+  }, [location, ga]);
 
   return (
     <div

--- a/react-app/src/components/Page/index.js
+++ b/react-app/src/components/Page/index.js
@@ -1,7 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { css } from 'styled-components/macro';
 
+import { useLocation } from 'react-router-dom';
+
 const Page = ({ className, children }) => {
+  const location = useLocation();
+
+  useEffect(() => {
+    // TODO: Make tag an environment variable (?)
+    window?.ga?.('gtag_UA_162388545_1.send', 'pageview', location.pathname); // eslint-disable-line no-unused-expressions
+  }, [location, window?.ga]);
+
   return (
     <div
       className={className}

--- a/react-app/src/pages/DonatePage/index.js
+++ b/react-app/src/pages/DonatePage/index.js
@@ -64,6 +64,18 @@ const DonatePage = ({ className }) => {
 
     try {
       const response = await axios.post('/api/match', payload);
+
+      /* eslint-disable no-unused-expressions */
+      window?.ga?.(
+        'gtag_UA_162388545_1.send',
+        'event',
+        'api',
+        'match',
+        'organization',
+        response?.data?.best_match?.id
+      );
+      /* eslint-enable no-unused-expressions */
+
       const data = response?.data?.best_match;
       setNearestOrganization(data);
     } catch (e) {


### PR DESCRIPTION
## Changes
* Added code to React app to fire page view events for client side route changes
* Added code to React app to fire events when a match is returned
* (In GA) added filter + view to filter out non-production data

## Screens
![2020-04-12 09 33 27](https://user-images.githubusercontent.com/13979068/79074368-c92cf600-7ca0-11ea-8a8f-cd3e5ad2dbfc.gif)

![Screen Shot 2020-04-12 at 9 34 48 AM](https://user-images.githubusercontent.com/13979068/79074387-e1047a00-7ca0-11ea-8a9e-ae8cfd3c5a17.png)

## Other Notes
These changes track metrics client-side, so ad-blockers may affect the numbers. For more accurate data, we should consider moving to [server-side analytics](https://developers.google.com/analytics/devguides/collection/protocol/v1/). However, using both server-side metrics and client-side metrics alone would result in duplicate page view events. This would require one of the following:
  * Remove GA snippet from client and only use server-side metrics. This is easier but not ideal, as we would lose information only available on the client (e.g. cookies that identify a unique anonymous user, location data, etc).
  * Remove GA snippet from client and add server-side workarounds for missing data (needs research)
  * Keep GA snippet on client but deduplicate page views (also needs research)