### PR TITLE
Bug in build.sh, don't deploy nginx container locally

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,14 +1,9 @@
 docker-compose down
 
-# Build UI
 (cd react-app; ./build.sh)
-# Build All Docker Images
 docker-compose build
 
-# Run Flask App and Postgres
-# Don't build nginx container locally
-docker-compose up web ui db
+docker-compose up
 
-# Create tables and insert dummy data
 docker exec -it covid-hackathon_db_1 psql -h 127.0.0.1 -p 5432 help_directory -U postgres -f createdb.sql
 docker exec -it covid-hackathon_db_1 psql -h 127.0.0.1 -p 5432 help_directory -U postgres -f insert_dummy_data.sql


### PR DESCRIPTION
For convenience, a deploy.sh that's similar to the old build.sh
script can be used to deploy changes to production.